### PR TITLE
Add print

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[dev]
+	  python -m pip install .[dev]
+          python -m pip install pytest
       - name: Test with pytest
         run: |
           py.test tests

--- a/clvm/operators.py
+++ b/clvm/operators.py
@@ -9,6 +9,7 @@ KEYWORDS = (
     "substr strlen point_add pubkey_for_exp concat sha256tree > >s "
     "logand logior logxor lognot ash lsh "
     "softfork "
+    "print "
 ).split()
 
 KEYWORD_FROM_ATOM = {int_to_bytes(k): v for k, v in enumerate(KEYWORDS)}

--- a/clvm/run_program.py
+++ b/clvm/run_program.py
@@ -24,6 +24,7 @@ def run_program(
     program,
     args,
     quote_kw,
+    print_kw,
     operator_lookup,
     max_cost=None,
     pre_eval_op=None,
@@ -86,6 +87,19 @@ def run_program(
 
         op = operator.as_atom()
         operand_list = sexp.rest()
+
+        if op == print_kw:
+            print("sexp:", sexp)
+            print("args:", args)
+            print("argb:", args.as_bin())
+            print("vals:", value_stack)
+            print("--")
+
+        if op == print_kw:
+            op_stack.append(eval_op)
+            value_stack.append(operand_list.first().cons(args))
+            return 1
+
         if op == quote_kw:
             if operand_list.nullp() or not operand_list.rest().nullp():
                 raise EvalError("quote requires exactly 1 parameter", sexp)
@@ -94,6 +108,7 @@ def run_program(
 
         op_stack.append(apply_op)
         value_stack.append(operator)
+
         while not operand_list.nullp():
             _ = operand_list.first()
             value_stack.append(_.cons(args))


### PR DESCRIPTION
This commit intentionally does not add an op_print opcode.
    The print atom is intended for debugging in a development environment.
    print passes through the value of its reduced arguments, so it can be inserted anywhere in the tree.
