### PR TITLE
remove unused validate() function on SExp class

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -95,15 +95,6 @@ class SExp(CLVMObject):
         sexp_to_stream(self, f)
         return f.getvalue()
 
-    def validate(self):
-        pair = self.pair
-        if pair:
-            assert len(pair) == 2
-            pair[0].validate()
-            pair[1].validate()
-        else:
-            assert isinstance(self.atom, bytes)
-
     @classmethod
     def to(class_, v: CastableType):
         if isinstance(v, class_):


### PR DESCRIPTION
It's also recursive which makes it a bit risky to leave around, in case it's used on untrusted input