### PR TITLE
make SExp.to() non-recursive

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -98,13 +98,13 @@ class SExp(CLVMObject):
 
                 raise ValueError("can't cast to %s: %s" % (class_, v))
             if op == 1: # set left
-                stack[target] = (stack.pop(), stack[target][1])
+                stack[target] = (CLVMObject(stack.pop()), stack[target][1])
                 continue
             if op == 2: # set right
-                stack[target] = (stack[target][0], stack.pop())
+                stack[target] = (stack[target][0], CLVMObject(stack.pop()))
                 continue
             if op == 3: # prepend list
-                stack[target] = (stack.pop(), stack[target])
+                stack[target] = (class_(stack.pop()), stack[target])
                 continue
         # there's exactly one item left at this point
         if len(stack) != 1:

--- a/tests/as_python_test.py
+++ b/tests/as_python_test.py
@@ -100,10 +100,39 @@ class AsPythonTest(unittest.TestCase):
         self.assertEqual(SExp.to('foobar').as_atom(), b'foobar')
 
     def test_deep_recursion(self):
-        d = [b"2"]
-        for i in range(480):
+        d = b'2'
+        for i in range(1000):
             d = [d]
-#        self.check_as_python(d)
+        v = SExp.to(d)
+        for i in range(1000):
+            self.assertEqual(v.as_pair()[1].as_atom(), SExp.null())
+            v = v.as_pair()[0]
+            d = d[0]
+
+        self.assertEqual(v.as_atom(), b'2')
+        self.assertEqual(d, b'2')
+
+    def test_long_linked_list(self):
+        d = b''
+        for i in range(1000):
+            d = (b'2', d)
+        v = SExp.to(d)
+        for i in range(1000):
+            self.assertEqual(v.as_pair()[0].as_atom(), d[0])
+            v = v.as_pair()[1]
+            d = d[1]
+
+        self.assertEqual(v.as_atom(), SExp.null())
+        self.assertEqual(d, b'')
+
+    def test_long_list(self):
+        d = [1337] * 1000
+        v = SExp.to(d)
+        for i in range(1000 - 1):
+            self.assertEqual(v.as_pair()[0].as_int(), d[i])
+            v = v.as_pair()[1]
+
+        self.assertEqual(v.as_atom(), SExp.null())
 
     def test_invalid_type(self):
         self.assertRaises(ValueError, lambda: SExp.to(dummy_class))


### PR DESCRIPTION
to not fail because of stack overflow. I also extended the tests with large structures (that otherwise would cause a stack overflow).

The reason these new tests can't use `self.check_as_python()` is because it uses the built-in comparison function in python, which is recursive, and fails with stack overflow.

I also tried to add this test:

```
self.check_as_python(((b"2", b"3"), (b"", b"1")))
```

But it failed by producing the wrong output. It does in current `develop` as well, so it seems the `SExp.to()` and `as_python()` don't round-trip. @richardkiss is that a problem?