### PR TITLE
make to_sexp_type a free function

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -29,87 +29,86 @@ CastableType = typing.Union[
 NULL = b""
 
 
+def to_sexp_type(
+    v: CastableType,
+) -> SExpType:
+    stack = [v]
+    ops = [(0, None)]  # convert
+
+    while len(ops) > 0:
+        op, target = ops.pop()
+        # convert value
+        if op == 0:
+            v = stack.pop()
+            if isinstance(v, tuple):
+                if len(v) != 2:
+                    raise ValueError("can't cast tuple of size %d" % len(v))
+                left, right = v
+                target = len(stack)
+                stack.append((left, right))
+                if type(right) != CLVMObject:
+                    stack.append(right)
+                    ops.append((2, target))  # set right
+                    ops.append((0, None))  # convert
+                if type(left) != CLVMObject:
+                    stack.append(left)
+                    ops.append((1, target))  # set left
+                    ops.append((0, None))  # convert
+                continue
+            if isinstance(v, CLVMObject):
+                stack.append(v.pair or v.atom)
+                continue
+            if isinstance(v, bytes):
+                stack.append(v)
+                continue
+            if isinstance(v, str):
+                stack.append(v.encode())
+                continue
+            if isinstance(v, int):
+                stack.append(int_to_bytes(v))
+                continue
+            if isinstance(v, G1Element):
+                stack.append(bytes(v))
+                continue
+            if v is None:
+                stack.append(NULL)
+                continue
+            if v == []:
+                stack.append(NULL)
+                continue
+
+            if hasattr(v, "__iter__"):
+                target = len(stack)
+                stack.append(NULL)
+                for _ in v:
+                    stack.append(_)
+                    ops.append((3, target))  # prepend list
+                    # we only need to convert if it's not already the right
+                    # type
+                    if type(_) != CLVMObject:
+                        ops.append((0, None))  # convert
+                continue
+
+            raise ValueError("can't cast to CLVMObject: %s" % v)
+        if op == 1:  # set left
+            stack[target] = (CLVMObject(stack.pop()), stack[target][1])
+            continue
+        if op == 2:  # set right
+            stack[target] = (stack[target][0], CLVMObject(stack.pop()))
+            continue
+        if op == 3:  # prepend list
+            stack[target] = (CLVMObject(stack.pop()), CLVMObject(stack[target]))
+            continue
+    # there's exactly one item left at this point
+    if len(stack) != 1:
+        raise ValueError("internal error")
+    return stack[0]
+
+
 class SExp(CLVMObject):
     true: "SExp"
     false: "SExp"
     __null__: "SExp"
-
-    @classmethod
-    def _to_sexp_type(
-        class_,
-        v: CastableType,
-    ) -> SExpType:
-        stack = [v]
-        ops = [(0, None)]  # convert
-
-        while len(ops) > 0:
-            op, target = ops.pop()
-            # convert value
-            if op == 0:
-                v = stack.pop()
-                if isinstance(v, tuple):
-                    if len(v) != 2:
-                        raise ValueError("can't cast tuple of size %d" % len(v))
-                    left, right = v
-                    target = len(stack)
-                    stack.append((left, right))
-                    if type(right) != CLVMObject:
-                        stack.append(right)
-                        ops.append((2, target))  # set right
-                        ops.append((0, None))  # convert
-                    if type(left) != CLVMObject:
-                        stack.append(left)
-                        ops.append((1, target))  # set left
-                        ops.append((0, None))  # convert
-                    continue
-                if isinstance(v, CLVMObject):
-                    stack.append(v.pair or v.atom)
-                    continue
-                if isinstance(v, bytes):
-                    stack.append(v)
-                    continue
-                if isinstance(v, str):
-                    stack.append(v.encode())
-                    continue
-                if isinstance(v, int):
-                    stack.append(int_to_bytes(v))
-                    continue
-                if isinstance(v, G1Element):
-                    stack.append(bytes(v))
-                    continue
-                if v is None:
-                    stack.append(NULL)
-                    continue
-                if v == []:
-                    stack.append(NULL)
-                    continue
-
-                if hasattr(v, "__iter__"):
-                    target = len(stack)
-                    stack.append(NULL)
-                    for _ in v:
-                        stack.append(_)
-                        ops.append((3, target))  # prepend list
-                        # we only need to convert if it's not already the right
-                        # type
-                        if type(_) != CLVMObject:
-                            ops.append((0, None))  # convert
-                    continue
-
-                raise ValueError("can't cast to %s: %s" % (class_, v))
-            if op == 1:  # set left
-                stack[target] = (CLVMObject(stack.pop()), stack[target][1])
-                continue
-            if op == 2:  # set right
-                stack[target] = (stack[target][0], CLVMObject(stack.pop()))
-                continue
-            if op == 3:  # prepend list
-                stack[target] = (CLVMObject(stack.pop()), CLVMObject(stack[target]))
-                continue
-        # there's exactly one item left at this point
-        if len(stack) != 1:
-            raise ValueError("internal error")
-        return stack[0]
 
     def as_pair(self):
         pair = self.pair
@@ -138,7 +137,7 @@ class SExp(CLVMObject):
     def to(class_, v: CastableType):
         if isinstance(v, class_):
             return v
-        v1 = class_._to_sexp_type(v)
+        v1 = to_sexp_type(v)
         return class_(v1)
 
     def cons(self, right: "CLVMObject"):


### PR DESCRIPTION
it doesn't use anything from the SExp class so it doesn't need to be a member