### PR TITLE
force the trace tests to run with the python back-end

### DIFF
--- a/tests/brun/trace-1.txt
+++ b/tests/brun/trace-1.txt
@@ -1,4 +1,4 @@
-brun -c -v '(+ (q 10) (f 1))' '(51)'
+brun --backend=python -c -v '(+ (q 10) (f 1))' '(51)'
 cost = 84
 61
 

--- a/tests/brun/trace-2.txt
+++ b/tests/brun/trace-2.txt
@@ -1,4 +1,4 @@
-brun -c -v '(x)'
+brun --backend=python -c -v '(x)'
 FAIL: clvm raise ()
 
 ((c (f 1) (r 1))) [((x))] => (didn't finish)


### PR DESCRIPTION
The rust implementation does not support the pre-eval hooks. This change lets the rust implementation use these same test cases unmodified