### PR TITLE
Update to new version of blspy and use PrivateKey to multiply

### DIFF
--- a/clvm/more_ops.py
+++ b/clvm/more_ops.py
@@ -1,7 +1,7 @@
 import hashlib
 import io
 
-from blspy import G1Element
+from blspy import G1Element, PrivateKey
 
 from .EvalError import EvalError
 from .casts import limbs_for_int
@@ -191,8 +191,9 @@ def op_gr_bytes(args):
 def op_pubkey_for_exp(args):
     ((i0, l0),) = args_as_int_list("pubkey_for_exp", args, 1)
     i0 %= 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
+    exponent = PrivateKey.from_bytes(i0.to_bytes(32, "big"))
     try:
-        r = args.to(bytes(G1Element.generator() * i0))
+        r = args.to(bytes(exponent.get_g1()))
         cost = PUBKEY_BASE_COST
         cost += l0 // PUBKEY_COST_PER_BYTE_DIVIDER
         return cost, r
@@ -202,7 +203,7 @@ def op_pubkey_for_exp(args):
 
 def op_point_add(items):
     cost = POINT_ADD_BASE_COST
-    p = G1Element.generator() * 0
+    p = G1Element()
 
     for _ in items.as_iter():
         if _.pair:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "rt") as fh:
     long_description = fh.read()
 
 dependencies = [
-    "blspy>=0.2.3",
+    "blspy>=0.9",
 ]
 
 dev_dependencies = [

--- a/tests/bls12_381_test.py
+++ b/tests/bls12_381_test.py
@@ -1,7 +1,6 @@
 import unittest
 
-from blspy import G1Element
-
+from blspy import G1Element, PrivateKey
 
 bls12_381_generator = G1Element.generator()
 
@@ -9,7 +8,7 @@ bls12_381_generator = G1Element.generator()
 class BLS12_381_Test(unittest.TestCase):
     def test_stream(self):
         for _ in range(1, 64):
-            p = bls12_381_generator * _
+            p = PrivateKey.from_bytes(_.to_bytes(32, "big")).get_g1()
             blob = bytes(p)
             p1 = G1Element.from_bytes(blob)
             self.assertEqual(len(blob), 48)


### PR DESCRIPTION
PrivateKey should be used for representing ints, and constructor for infinity element