### PR TITLE
SExp constructor

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -76,6 +76,9 @@ def to_sexp_type(
             if v == []:
                 stack.append(NULL)
                 continue
+            if hasattr(v, "pair") and hasattr(v, "atom"):
+                stack.append(v.pair or v.atom)
+                continue
 
             if hasattr(v, "__iter__"):
                 target = len(stack)


### PR DESCRIPTION
allow SExp to be constructed from anything implementing the CLVMObject protocol

namely a `pair` and `atom` member. The comment in `CLVMObject` seem to suggest this was the intention