### PR TITLE
My take on dialects, which I think is now uniform in interface with the run_program from stage_0

### DIFF
--- a/clvm/__init__.py
+++ b/clvm/__init__.py
@@ -1,5 +1,6 @@
 from .SExp import SExp
-from .dialect import Dialect  # noqa
+from .dialect import Dialect
+from .chia_dialect import dialect_factories  # noqa
 from .operators import (  # noqa
     QUOTE_ATOM,  # deprecated
     KEYWORD_TO_ATOM,

--- a/clvm/chia_dialect_constants.py
+++ b/clvm/chia_dialect_constants.py
@@ -1,0 +1,28 @@
+from .casts import int_to_bytes
+
+KEYWORDS = (
+    # core opcodes 0x01-x08
+    ". q a i c f r l x "
+
+    # opcodes on atoms as strings 0x09-0x0f
+    "= >s sha256 substr strlen concat . "
+
+    # opcodes on atoms as ints 0x10-0x17
+    "+ - * / divmod > ash lsh "
+
+    # opcodes on atoms as vectors of bools 0x18-0x1c
+    "logand logior logxor lognot . "
+
+    # opcodes for bls 1381 0x1d-0x1f
+    "point_add pubkey_for_exp . "
+
+    # bool opcodes 0x20-0x23
+    "not any all . "
+
+    # misc 0x24
+    "softfork "
+).split()
+
+KEYWORD_FROM_ATOM = {int_to_bytes(k): v for k, v in enumerate(KEYWORDS)}
+KEYWORD_TO_ATOM = {v: k for k, v in KEYWORD_FROM_ATOM.items()}
+

--- a/clvm/dialect.py
+++ b/clvm/dialect.py
@@ -1,10 +1,11 @@
 from typing import Callable, Optional, Tuple
-
+from .SExp import SExp
 try:
     import clvm_rs
 except ImportError:
     clvm_rs = None
 
+import io
 from . import core_ops, more_ops
 from .chainable_multi_op_fn import ChainableMultiOpFn
 from .handle_unknown_op import (
@@ -13,6 +14,7 @@ from .handle_unknown_op import (
 )
 from .run_program import _run_program
 from .types import CLVMObjectType, ConversionFn, MultiOpFn, OperatorDict
+from clvm.serialize import sexp_from_stream, sexp_to_stream
 
 
 OP_REWRITE = {
@@ -79,6 +81,9 @@ class Dialect:
         self.opcode_lookup = dict()
         self.multi_op_fn = ChainableMultiOpFn(self.opcode_lookup, multi_op_fn)
         self.to_python = to_python
+
+    def configure(self, **kwargs):
+        pass
 
     def update(self, d: OperatorDict) -> None:
         self.opcode_lookup.update(d)

--- a/clvm/operators.py
+++ b/clvm/operators.py
@@ -7,9 +7,8 @@ from . import core_ops, more_ops
 from .CLVMObject import CLVMObject
 from .op_utils import operators_for_module
 from .handle_unknown_op import handle_unknown_op_softfork_ready
-from .chia_dialect import KEYWORDS, KEYWORD_FROM_ATOM, KEYWORD_TO_ATOM  # noqa
 from .dialect import OP_REWRITE
-
+from .chia_dialect_constants import KEYWORDS, KEYWORD_FROM_ATOM, KEYWORD_TO_ATOM  # noqa
 
 class OperatorDict(dict):
     """
@@ -33,11 +32,11 @@ class OperatorDict(dict):
             self.unknown_op_handler = handle_unknown_op_softfork_ready
         return self
 
-    def __call__(self, op: bytes, arguments: CLVMObject) -> Tuple[int, CLVMObject]:
+    def __call__(self, op: bytes, arguments: CLVMObject, max_cost=None) -> Tuple[int, CLVMObject]:
         f = self.get(op)
         if f is None:
             try:
-                return self.unknown_op_handler(op, arguments, max_cost=None)
+                return self.unknown_op_handler(op, arguments, max_cost)
             except TypeError:
                 return self.unknown_op_handler(op, arguments)
         else:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ with open("README.md", "rt") as fh:
 
 dependencies = [
     "blspy>=0.9",
+    "clvm_rs>=0.1.8"
 ]
 
 dev_dependencies = [


### PR DESCRIPTION
May be controversial.

I made cuts needed to move some constants into a place where importing them would be possible from anywhere, improving dependency congestion.

Main visible differences:

- There is now a dialect_factories collection the end user can use to get sane dialects.
- Configuring a dialect to be a standard chia clvm runner is now a function that most python based dialects can use.
- A configure method on dialects allows implementation specific communication

As used in clvm_tools, it's now possible to

            ````
            backend = args.backend if args.backend is not None else "python"
            dialect = dialect_factories[backend](
                KEYWORD_TO_ATOM["q"],
                KEYWORD_TO_ATOM["a"],
                args.strict,
                to_sexp_f
            )

            cost, result = dialect.run_program(
                run_script, input_sexp, max_cost=max_cost, pre_eval_f=pre_eval_f)
            ````

The dialect object is factored out of global paths, so it at least owns all its own information.