### PR TITLE
Improve `sexp_buffer_from_stream` performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 pip-wheel-metadata
 venv
 .venv
+.idea/

--- a/clvm/serialize.py
+++ b/clvm/serialize.py
@@ -10,7 +10,7 @@
 # 0xe0-0xef is 3 bytes ((perform logical and of first byte with 0xf))
 # 0xf0-0xf7 is 4 bytes ((perform logical and of first byte with 0x7))
 # 0xf7-0xfb is 5 bytes ((perform logical and of first byte with 0x3))
-
+import io
 from .CLVMObject import CLVMObject
 
 
@@ -147,15 +147,15 @@ def _consume_atom(f, b):
 # that represent on S-expression tree, and returns them. This is more efficient
 # than parsing and returning a python S-expression tree.
 def sexp_buffer_from_stream(f):
-    ret = b''
+    ret = io.BytesIO()
 
     depth = 1
     while depth > 0:
         depth -= 1
         buf, d = _op_consume_sexp(f)
         depth += d
-        ret += buf
-    return ret
+        ret.write(buf)
+    return ret.getvalue()
 
 
 def _atom_from_stream(f, b, to_sexp):


### PR DESCRIPTION
# Summary
When I develop [clvm-js](https://github.com/Chia-Mine/clvm-js/blob/v0.0.19/CHANGELOG.md) as a JavaScript implementation of `clvm`, I was suffered in poor performance in `test_very_deep_tree` at `tests/serialize_test`.

Later I found out that the root cause was huge number of memory allocation/copy invoked upon byte deserialization of sexp instance.

Looking back to `clvm` of original Python implementation, I noticed that one of the optimizations I applied to my JavaScript implementation can also be applied to the Python's.

So here I am proposing the pure performance enhancement of `sexp_buffer_from_stream`.

# Performance measurement
## Test environment
|  - | - |
| --- | ---------------------------|
| OS | Windows10 Pro |
| CPU | AMD Ryzen9 5900X |
| MEM | 64GB@3200MHz |
| Storage | NVMe m.2 SSD Corsair MP600 |
| Python | 3.7.8 |

```powershell
# Powershell
cd clvm/tests
for($i=0; $i -lt 10; $i++){ python -m unittest serialize_test.SerializeTest.test_very_deep_tree }
```

## Result
Roughly 10-20% faster than before.

**test_very_deep_tree**
| n | Before the PR | After the PR |
| - |------ | ------ |
| 1 | 5.023s | 4.014s |
| 2 | 4.696s | 3.996s |
| 3 | 4.882s | 4.021s |
| 4 | 4.403s | 3.993s |
| 5 | 4.596s | 3.997s |
| 6 | 4.561s | 3.983s |
| 7 | 4.453s | 3.987s |
| 8 | 4.442s | 3.998s |
| 9 | 4.493s | 3.996s |
| 10 | 4.468s | 3.990s |
| AVG | 4.602s | 3.998s |



# P.S.

If you're interested, I also compared performance between `clvm` of Python and [`clvm` of JavaScript](https://github.com/Chia-Mine/clvm-js).

## Test execution
**Python**
```powershell
# Powershell
cd <directory>
git clone https://github.com/Chia-Network/clvm
cd clvm/tests
for($i=0; $i -lt 10; $i++){ python -m unittest serialize_test.SerializeTest.test_very_deep_tree }
for($i=0; $i -lt 10; $i++){ python -m unittest serialize_test.SerializeTest.test_very_long_blobs }
```
**JS**
```powershell
# Powershell
cd <directory>
git clone https://github.com/Chia-Mine/clvm-js
cd clvm-js
git checkout v0.0.19
yarn # Or npm install
for($i=0; $i -lt 10; $i++){ yarn test serialize_test --testNamePattern test_very_deep_tree } 
for($i=0; $i -lt 10; $i++){ yarn test serialize_test --testNamePattern test_very_long_blobs } 
```

## Result
**test_very_deep_tree**  
|  | Python | JS |
| - |------ | ------ |
| 1 | 4.014s | 2.29s |
| 2 | 3.996s | 2.3s |
| 3 | 4.021s | 2.288s |
| 4 | 3.993s | 2.251s |
| 5 | 3.997s | 2.254s |
| 6 | 3.983s | 2.289s |
| 7 | 3.987s | 2.253s |
| 8 | 3.998s | 2.26s |
| 9 | 3.996s | 2.301s |
| 10s | 3.99s | 2.282s |
| AVG | 3.998s | 2.277s |

**test_very_long_blobs**  
|  | Python | JS |
| - |------ | ------ |
| 1 | 0.454s | 0.791s |
| 2 | 0.455s | 0.741s |
| 3 | 0.478s | 0.77s |
| 4 | 0.466s | 0.798s |
| 5 | 0.474s | 0.799s |
| 6 | 0.479s | 0.807s |
| 7 | 0.467s | 0.818s |
| 8 | 0.488s | 0.751s |
| 9 | 0.423s | 0.758s |
| 10s | 0.47s | 0.743s |
| AVG | 0.4654s | 0.7778s |
