### PR TITLE
Compiler improvement

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -141,11 +141,11 @@ class SExp:
     # SExp objects with higher level functions, or None
     pair: typing.Optional[typing.Tuple[typing.Any, typing.Any]]
 
-    def __init__(self, obj):
+    def __init__(self, obj, _bin=None):
         self.atom = obj.atom
         self.pair = obj.pair
 
-        self._bin = None
+        self._bin = _bin
 
     # this returns a tuple of two SExp objects, or None
     def as_pair(self) -> typing.Tuple["SExp", "SExp"]:
@@ -213,7 +213,10 @@ class SExp:
             v = v.rest()
 
     def __eq__(self, other: CastableType):
-        return self.as_bin() == self.to(other).as_bin()
+        try:
+            return self.as_bin() == self.to(other).as_bin()
+        except ValueError:
+            return False
 
     def list_len(self):
         v = self

--- a/clvm/run_program.py
+++ b/clvm/run_program.py
@@ -60,6 +60,8 @@ def run_program(
         pre_eval_op = None
 
     def traverse_path(sexp: SExp, env: SExp) -> Tuple[int, SExp]:
+        original_env = SExp(env)
+
         cost = PATH_LOOKUP_BASE_COST
         cost += PATH_LOOKUP_COST_PER_LEG
         if sexp.nullp():
@@ -83,7 +85,7 @@ def run_program(
         bitmask = 0x01
         while byte_cursor > end_byte_cursor or bitmask < end_bitmask:
             if env.pair is None:
-                raise EvalError("path into atom", env)
+                raise EvalError("path into atom while running traverse_path '%s' on" % sexp, original_env)
             if b[byte_cursor] & bitmask:
                 env = env.rest()
             else:

--- a/clvm/serialize.py
+++ b/clvm/serialize.py
@@ -21,16 +21,13 @@ CONS_BOX_MARKER = 0xFF
 
 
 def sexp_to_byte_iterator(sexp):
-    todo_stack = [sexp]
-    while todo_stack:
-        sexp = todo_stack.pop()
-        pair = sexp.as_pair()
-        if pair:
-            yield bytes([CONS_BOX_MARKER])
-            todo_stack.append(pair[1])
-            todo_stack.append(pair[0])
-        else:
-            yield from atom_to_byte_iterator(sexp.as_atom())
+    pair = sexp.as_pair()
+    if pair:
+        yield bytes([CONS_BOX_MARKER])
+        yield pair[0].as_bin()
+        yield pair[1].as_bin()
+    else:
+        yield from atom_to_byte_iterator(sexp.as_atom())
 
 
 def atom_to_byte_iterator(as_atom):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ dev_dependencies = [
 
 setup(
     name="clvm",
+    version="0.9.7",
     packages=["clvm",],
     author="Chia Network, Inc.",
     author_email="hello@chia.net",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ dev_dependencies = [
 
 setup(
     name="clvm",
-    version="0.9.7",
     packages=["clvm",],
     author="Chia Network, Inc.",
     author_email="hello@chia.net",


### PR DESCRIPTION
- Caching serialization results
- Use recursion instead of iteration for `sexp_to_byte`
- Improve `looks_like_clvm_object`
- More verbose `"path into atom"` error