### PR TITLE
remove special case for `G1Element` in `SExp.to()`

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -1,7 +1,6 @@
 import io
 import typing
 
-from blspy import G1Element
 
 from .as_python import as_python
 from .CLVMObject import CLVMObject
@@ -22,7 +21,6 @@ CastableType = typing.Union[
     str,
     int,
     None,
-    G1Element,
     list,
     typing.Tuple[typing.Any, typing.Any],
 ]
@@ -38,7 +36,7 @@ def looks_like_clvm_object(o: typing.Any) -> bool:
 
 # this function recognizes some common types and turns them into plain bytes,
 def convert_atom_to_bytes(
-    v: typing.Union[bytes, str, int, G1Element, None, list],
+    v: typing.Union[bytes, str, int, None, list],
 ) -> bytes:
 
     if isinstance(v, bytes):
@@ -47,12 +45,12 @@ def convert_atom_to_bytes(
         return v.encode()
     if isinstance(v, int):
         return int_to_bytes(v)
-    if isinstance(v, G1Element):
-        return bytes(v)
     if v is None:
         return b""
     if v == []:
         return b""
+    if hasattr(v, "__bytes__"):
+        return bytes(v)
 
     raise ValueError("can't cast %s (%s) to bytes" % (type(v), v))
 

--- a/tests/to_sexp_test.py
+++ b/tests/to_sexp_test.py
@@ -50,6 +50,11 @@ def print_tree(tree: SExp) -> str:
     return ret
 
 
+class DummyByteConvertible:
+    def __bytes__(self) -> bytes:
+        return b"foobar"
+
+
 class ToSExpTest(unittest.TestCase):
     def test_cast_1(self):
         # this was a problem in `clvm_tools` and is included
@@ -159,6 +164,8 @@ class ToSExpTest(unittest.TestCase):
         assert convert_atom_to_bytes(b"foobar") == b"foobar"
         assert convert_atom_to_bytes(None) == b""
         assert convert_atom_to_bytes([]) == b""
+
+        assert convert_atom_to_bytes(DummyByteConvertible()) == b"foobar"
 
         with self.assertRaises(ValueError):
             assert convert_atom_to_bytes([1, 2, 3])


### PR DESCRIPTION
Instead support any type that can convert to `bytes`.