### PR TITLE
drop python 3.7 on CI. Bump runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: [ '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -25,10 +25,10 @@ jobs:
         fetch-depth: 0
     - run: |
         git fetch origin +refs/tags/*:refs/tags/*
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install pep517
       run: >-
         python -m


### PR DESCRIPTION
the ubuntu-18 runner appears to be non-existent.

https://github.com/Chia-Network/clvm/actions/runs/5884832753