### PR TITLE
Add python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11']
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/clvm/version.py
+++ b/clvm/version.py
@@ -1,6 +1,5 @@
 import importlib_metadata
 
-__version__: str
 try:
     __version__ = importlib_metadata.version(__name__)
 except importlib_metadata.PackageNotFoundError:

--- a/clvm/version.py
+++ b/clvm/version.py
@@ -1,7 +1,10 @@
-from pkg_resources import get_distribution, DistributionNotFound
+from __future__ import annotations
 
+import importlib.metadata
+
+__version__: str
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,13 @@ dependencies = [
     "chia_rs>=0.2.13",
 ]
 
-dev_dependencies = [
-    "clvm_tools>=0.4.4",
-    "pytest",
-]
+dev_dependencies = ["clvm_tools>=0.4.4", "pytest", "setuptools"]
 
 setup(
     name="clvm",
-    packages=["clvm",],
+    packages=[
+        "clvm",
+    ],
     author="Chia Network, Inc.",
     author_email="hello@chia.net",
     url="https://github.com/Chia-Network/clvm",
@@ -36,7 +35,9 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Security :: Cryptography",
     ],
-    extras_require=dict(dev=dev_dependencies,),
+    extras_require=dict(
+        dev=dev_dependencies,
+    ),
     project_urls={
         "Bug Reports": "https://github.com/Chia-Network/clvm",
         "Source": "https://github.com/Chia-Network/clvm",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "rt") as fh:
 
 dependencies = ["chia_rs>=0.2.13", "importlib_metadata~=6.11.0"]
 
-dev_dependencies = ["clvm_tools>=0.4.4", "pytest"]
+dev_dependencies = ["clvm_tools>=0.4.4", "pytest", "setuptools"]
 
 setup(
     name="clvm",

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,9 @@ from setuptools import setup
 with open("README.md", "rt") as fh:
     long_description = fh.read()
 
-dependencies = [
-    "chia_rs>=0.2.13",
-    "importlib_metadata~=6.11.0"
-]
+dependencies = ["chia_rs>=0.2.13", "importlib_metadata~=6.11.0"]
 
-dev_dependencies = ["clvm_tools>=0.4.4", "pytest", "setuptools"]
+dev_dependencies = ["clvm_tools>=0.4.4", "pytest"]
 
 setup(
     name="clvm",


### PR DESCRIPTION
Add 3.12 to the test matrix.
Added `setuptools` as a dev dependency as a workaround for `clvm_tools` needing it until that repo can get cleaned up to not use `pkg_resources`