### PR TITLE
Remove python 3.8 and update workflow to actually make source tarball

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: [ '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,25 +31,18 @@ jobs:
     - run: |
         git fetch origin +refs/tags/*:refs/tags/*
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.10
 
-    - name: Install pep517
-      run: >-
-        python -m
-        pip install
-        pep517
-        --user
-
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        pep517.build
-        --binary
-        --out-dir dist/
-        .
+    - name: Build a binary wheel and a source tarball 
+      run: |
+        python -m venv venv
+        source venv/bin/activate
+        python -m pip install --upgrade pip
+        pip install build
+        python -m build --outdir dist/ .
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Build a binary wheel and a source tarball 
       run: |


### PR DESCRIPTION
Remove python 3.8
Update workflow to use `build` and to actually make a source tarball. Previously only a binary wheel was generated.