### PR TITLE
remove `architecture: x64` from `setup-python` action call

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,6 @@ jobs:
         uses: chia-network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
https://github.com/Chia-Network/clvm/actions/runs/14005714256/job/39219837096?pr=168