### PR TITLE
Add a max_size passthrough for SExp::as_bin

### DIFF
--- a/clvm/SExp.py
+++ b/clvm/SExp.py
@@ -14,7 +14,7 @@ from .casts import (
     int_from_bytes,
     int_to_bytes,
 )
-from .serialize import sexp_to_stream
+from .serialize import sexp_to_stream, MAX_SAFE_BYTES
 
 
 CastableType = typing.Union[
@@ -186,9 +186,9 @@ class SExp:
             raise TypeError("Unable to convert a pair to an int")
         return int_from_bytes(self.atom)
 
-    def as_bin(self, *, allow_backrefs: bool = False) -> bytes:
+    def as_bin(self, *, allow_backrefs: bool = False, max_size=MAX_SAFE_BYTES) -> bytes:
         f = io.BytesIO()
-        sexp_to_stream(self, f, allow_backrefs=allow_backrefs)
+        sexp_to_stream(self, f, allow_backrefs=allow_backrefs, max_size=max_size)
         return f.getvalue()
 
     # TODO: should be `v: CastableType`

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -256,3 +256,27 @@ class SerializeTest(unittest.TestCase):
             io.BytesIO(serialized_sexp1_v2), to_sexp_f, allow_backrefs=True
         )
         self.assertTrue(deserialized_sexp1_v1 == deserialized_sexp1_v2)
+
+
+    # This tests that the max_size parameter in as_bin allows currently
+    # impossible objects to be converted to binary by passing max_size
+    # down to sexp_from_stream.
+    def test_as_bin_from_large_blob(self) -> None:
+        # Code cribbed from clvm_tools::serialize_test
+        text = b"the quick brown fox jumps over the lazy dogs"
+        size = 0x8000000
+        count = size // len(text)
+        s = text * count
+        v = to_sexp_f(s)
+
+        # Test that converting this results in an error without max_size
+        try:
+            b = v.as_bin()
+            self.assertTrue(False)
+        except:
+            pass
+
+        # Test that we can convert it back with max_size set.
+        b = v.as_bin(max_size=0x40000000)
+        converted_back = sexp_from_stream(io.BytesIO(b), to_sexp_f).as_python()
+        self.assertEqual(converted_back, s)

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -261,12 +261,11 @@ class SerializeTest(unittest.TestCase):
     # This tests that the max_size parameter in as_bin allows currently
     # impossible objects to be converted to binary by passing max_size
     # down to sexp_from_stream.
-    def test_as_bin_from_large_blob(self) -> None:
+    def test_as_bin_creating_large_blob(self) -> None:
         # Code cribbed from clvm_tools::serialize_test
-        text = b"the quick brown fox jumps over the lazy dogs"
         size = 0x8000000
-        count = size // len(text)
-        s = text * count
+        count = size // len(TEXT)
+        s = TEXT * count
         v = to_sexp_f(s)
 
         # Test that converting this results in an error without max_size


### PR DESCRIPTION
and add a test that verifies that it increases the amount of data that as_bin will tolerate.